### PR TITLE
Optimizes SQL queries to reduce contention when a partition split is requested or an attempt is made to acquire a partition

### DIFF
--- a/source/EXBP.Dipren.Data.Postgres/PostgresEngineDataStoreImplementation.cs
+++ b/source/EXBP.Dipren.Data.Postgres/PostgresEngineDataStoreImplementation.cs
@@ -680,6 +680,7 @@ namespace EXBP.Dipren.Data.Postgres
 
                 command.Parameters.AddWithValue("@job_id", NpgsqlDbType.Char, COLUMN_JOB_NAME_LENGTH, jobId);
                 command.Parameters.AddWithValue("@active", NpgsqlDbType.Timestamp, uktsActive);
+                command.Parameters.AddWithValue("@candidates", NpgsqlDbType.Integer, MAXIMUM_CANDIDATES);
 
                 int affected = await command.ExecuteNonQueryAsync(cancellation);
 

--- a/source/EXBP.Dipren.Data.Postgres/PostgresEngineDataStoreImplementationResources.Designer.cs
+++ b/source/EXBP.Dipren.Data.Postgres/PostgresEngineDataStoreImplementationResources.Designer.cs
@@ -431,7 +431,7 @@ namespace EXBP.Dipren.Data.Postgres {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to WITH &quot;candidate&quot; AS
+        ///   Looks up a localized string similar to WITH &quot;candidates&quot; AS
         ///(
         ///  SELECT
         ///    &quot;id&quot;
@@ -446,17 +446,18 @@ namespace EXBP.Dipren.Data.Postgres {
         ///  ORDER BY
         ///    &quot;remaining&quot; DESC
         ///  LIMIT
-        ///    1
-        ///  FOR UPDATE
-        ///)
-        ///UPDATE
-        ///  &quot;dipren&quot;.&quot;partitions&quot; AS &quot;target&quot;
-        ///SET
-        ///  &quot;is_split_requested&quot; = TRUE
-        ///FROM
-        ///  &quot;candidate&quot;
-        ///WHERE
-        ///  (&quot;target&quot;.&quot;id&quot; = &quot;candidate&quot;.&quot;id&quot;);.
+        ///    @candidates
+        ///),
+        ///&quot;candidate&quot; AS
+        ///(
+        ///  SELECT
+        ///    t2.&quot;id&quot;
+        ///  FROM
+        ///    &quot;candidates&quot; AS t1
+        ///    INNER JOIN &quot;dipren&quot;.&quot;partitions&quot; AS t2 ON (t1.&quot;id&quot; = t2.&quot;id&quot;)
+        ///  WHERE
+        ///    (t2.&quot;job_id&quot; = @job_id) AND
+        ///    (t2.&quot;owne [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string QueryTryRequestSplit {
             get {

--- a/source/EXBP.Dipren.Data.Postgres/PostgresEngineDataStoreImplementationResources.resx
+++ b/source/EXBP.Dipren.Data.Postgres/PostgresEngineDataStoreImplementationResources.resx
@@ -456,7 +456,7 @@ RETURNING
   "is_split_requested" AS "is_split_requested";</value>
   </data>
   <data name="QueryTryRequestSplit" xml:space="preserve">
-    <value>WITH "candidate" AS
+    <value>WITH "candidates" AS
 (
   SELECT
     "id"
@@ -470,6 +470,24 @@ RETURNING
     ("is_split_requested" = FALSE)
   ORDER BY
     "remaining" DESC
+  LIMIT
+    @candidates
+),
+"candidate" AS
+(
+  SELECT
+    t2."id"
+  FROM
+    "candidates" AS t1
+    INNER JOIN "dipren"."partitions" AS t2 ON (t1."id" = t2."id")
+  WHERE
+    (t2."job_id" = @job_id) AND
+    (t2."owner" IS NOT NULL) AND
+    (t2."updated" &gt;= @active) AND
+    (t2."is_completed" = FALSE) AND
+    (t2."is_split_requested" = FALSE)
+  ORDER BY
+    RANDOM()
   LIMIT
     1
   FOR UPDATE


### PR DESCRIPTION
This change set is not integrated into the main branch as it seems to introduce some performance bottlenecks.

It modifies the queries for acquiring partitions and requesting splits so that it identifies 16 candidate partitions and picks one randomly from the candidates. In the current implementation, this seems much heavier than letting the database pick the partition with the most keys left to be processed. The reason could be that a split is requested every time a partition could not be acquired.